### PR TITLE
240226 박채현 백준 1057 토너먼트

### DIFF
--- a/witty/W02/1057.py
+++ b/witty/W02/1057.py
@@ -1,0 +1,13 @@
+import sys
+
+cnt = 1
+N, k, l = map(int, sys.stdin.readline().split())
+
+while True:
+    k = (k + 1) // 2
+    l = (l + 1) // 2
+    if k != l:
+        cnt += 1
+    else:
+        break
+print(cnt)


### PR DESCRIPTION
토너먼트 경기를 치르는 사람은 두 명이니까
쉽게 두 명씩 묶어서 그룹 번호를 매기고자 했음
ex) 1, 2(1번 그룹), 3, 4(2번 그룹), 5(3번 그룹)
부전승이여도 그룹을 맺은 이유는 (부전승도 경기를 했는데 무조건 이긴 경우) 로 가정하면 풀기 편해서임
그룹 번호는 (자신의 번호 + 1) // 2 (2로 나눈 몫)을 하면 구할 수 있음
그룹이 다르다는 건 해당 라운드에는 경기를 치르지 않는다는 소리임
여기서 관심 있는 건 두 명 뿐이니까, 그 두 명의 그룹 번호만 비교
두 명의 그룹 번호가 다르다면 카운트를 올림
같으면 드디어 경기를 치른다는 뜻이니까 반복문 탈출 후, 출력
